### PR TITLE
Align sample code with actual code

### DIFF
--- a/src/Docs/Pages/TableView.fs
+++ b/src/Docs/Pages/TableView.fs
@@ -206,7 +206,6 @@ let tableWithVisuals =
     ]
 
 Daisy.table [
-    table.compact
     prop.children [
         Html.thead [
             Html.tr [


### PR DESCRIPTION
In commit 80457ef3fa55a08c8f6e1b57414d58bdeec5dda5, the table.compact property was removed from the code used to generate the example, but it was left in the code sample shown with it. This change removes the property.