### PR TITLE
Add new themes

### DIFF
--- a/src/Docs/View.fs
+++ b/src/Docs/View.fs
@@ -57,8 +57,8 @@ let private rightSide state dispatch (title:string) (docLink:string) elm =
             "dim", "🔅 dim"
             "nord", "⛰️ nord"
             "sunset", "🌆 sunset"
-            "abyss", "🕳️ abyss"
             "caramellatte", "☕ caramellatte"
+            "abyss", "🕳️ abyss"
             "silk", "👗 silk"
         ]
 

--- a/src/Feliz.DaisyUI/Modifiers.fs
+++ b/src/Feliz.DaisyUI/Modifiers.fs
@@ -900,9 +900,18 @@ type theme =
     static member inline coffee = prop.custom("data-theme", "coffee")
     /// Set 'winter' theme
     static member inline winter = prop.custom("data-theme", "winter")
+    /// Set 'dim' theme
     static member inline dim = prop.custom("data-theme", "dim")
+    /// Set 'nord' theme
     static member inline nord = prop.custom("data-theme", "nord")
+    /// Set 'sunset' theme
     static member inline sunset = prop.custom("data-theme", "sunset")
+    /// Set 'caramellatte' theme
+    static member inline caramellatte = prop.custom("data-theme", "caramellatte")
+    /// Set 'abyss' theme
+    static member inline abyss = prop.custom("data-theme", "abyss")
+    /// Set 'silk' theme
+    static member inline silk = prop.custom("data-theme", "silk")
     /// Set custom theme
     static member inline custom (t:string) = prop.custom("data-theme", t)
     static member inline controller = prop.className "theme-controller"


### PR DESCRIPTION
I had just notice while upgrading my app from Feliz.DaisyUI 4 -> 5 that the 3 news themes weren't accessible from the "theme" type. I just went ahead and added them. :)