### PR TITLE
Fixed broken Drawer example and added DaisyUI.drawerButton binding

### DIFF
--- a/src/Docs/Pages/Drawer.fs
+++ b/src/Docs/Pages/Drawer.fs
@@ -14,7 +14,7 @@ let simple =
                 Daisy.drawerContent [
                     prop.className "flex flex-col items-center justify-center"
                     prop.children [
-                        Daisy.label [
+                        Html.label [
                             button.primary
                             prop.htmlFor "my-drawer"
                             prop.text "Open Menu"
@@ -44,7 +44,7 @@ let simple =
         Daisy.drawerContent [
             prop.className "flex flex-col items-center justify-center"
             prop.children [
-                Daisy.label [
+                Html.label [
                     button.primary
                     prop.htmlFor "my-drawer"
                     prop.text "Open Menu"


### PR DESCRIPTION
The old example used DaisyUI.label, which ends up as a html span. To fix this, drawerButton was added, which is a label that uses the "btn" and "drawer-button" classes.

Lastly, drawerButton was added to the drawer example.