### PR TITLE
Fixed broken Drawer example and added DaisyUI.drawerButton binding

### DIFF
--- a/src/Docs/Pages/Drawer.fs
+++ b/src/Docs/Pages/Drawer.fs
@@ -14,7 +14,7 @@ let simple =
                 Daisy.drawerContent [
                     prop.className "flex flex-col items-center justify-center"
                     prop.children [
-                        Daisy.label [
+                        Html.label [
                             button.primary
                             prop.htmlFor "my-drawer"
                             prop.text "Open Menu"
@@ -44,7 +44,7 @@ let simple =
         Daisy.drawerContent [
             prop.className "flex flex-col items-center justify-center"
             prop.children [
-                Daisy.label [
+                Html.label [
                     button.primary
                     prop.htmlFor "my-drawer"
                     prop.text "Open Menu"

--- a/src/Docs/Pages/Drawer.fs
+++ b/src/Docs/Pages/Drawer.fs
@@ -14,7 +14,7 @@ let simple =
                 Daisy.drawerContent [
                     prop.className "flex flex-col items-center justify-center"
                     prop.children [
-                        Html.label [
+                        Daisy.drawerButton [
                             button.primary
                             prop.htmlFor "my-drawer"
                             prop.text "Open Menu"
@@ -44,7 +44,7 @@ let simple =
         Daisy.drawerContent [
             prop.className "flex flex-col items-center justify-center"
             prop.children [
-                Html.label [
+                Daisy.drawerButton [
                     button.primary
                     prop.htmlFor "my-drawer"
                     prop.text "Open Menu"

--- a/src/Feliz.DaisyUI/DaisyUI.fs
+++ b/src/Feliz.DaisyUI/DaisyUI.fs
@@ -134,6 +134,10 @@ type Daisy =
     static member inline drawerContent (children: #seq<ReactElement>) = Helpers.Elm.children Html.div children "drawer-content"
     static member inline drawerContent elm = Helpers.Elm.elm Html.div elm "drawer-content"
 
+    static member inline drawerButton props = Helpers.Elm.props Html.label props "btn drawer-button"
+    static member inline drawerButton (children: #seq<ReactElement>) = Helpers.Elm.children Html.label children "btn drawer-button"
+    static member inline drawerButton elm = Helpers.Elm.elm Html.label elm "btn drawer-button"
+
     static member inline drawerSide props = Helpers.Elm.props Html.div props "drawer-side"
     static member inline drawerSide (children: #seq<ReactElement>) = Helpers.Elm.children Html.div children "drawer-side"
     static member inline drawerSide elm = Helpers.Elm.elm Html.div elm "drawer-side"


### PR DESCRIPTION
The old example used DaisyUI.label, which ends up as a html span. To fix this, drawerButton was added, which is a label that uses the "btn" and "drawer-button" classes.

Lastly, drawerButton was added to the drawer example.
